### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "gordon-food-service/gfs-installers",
+    "description": "Provide external dependencies in different locations in your Drupal application through Composer",
     "type": "composer-plugin",
     "license": "MIT",
     "autoload": {


### PR DESCRIPTION
composer.json file missing required property 'description'. Added a basic description after we received the following message from GitHub:

Missing argument delimiter can lead to code execution via VCS repository URLs or source download URLs on systems with Mercurial in composer

This is the only issue I could find with the file.